### PR TITLE
Update patch.sh

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -11,6 +11,7 @@ OnFailure=remarkable-fail.service
 After=home.mount
 
 [Service]
+Environment="QT_QPA_GENERIC_PLUGINS=evdevlamy"
 ExecStart=/usr/bin/xochitl --system -plugin evdevlamy
 Restart=on-failure
 WatchdogSec=60


### PR DESCRIPTION
The installation of [toltec](https://toltec-dev.org/) may destroy this plugin.
It'd better add the environment in the systemd service file.

```systemd
[Service]
Environment="QT_QPA_GENERIC_PLUGINS=evdevlamy"
```